### PR TITLE
Update communication.js by capitalizing the ZimbraError function

### DIFF
--- a/lib/api/communication.js
+++ b/lib/api/communication.js
@@ -526,7 +526,7 @@ CommunicationApi.prototype.send = function (request, callback) {
                             );
 
                             callback(
-                                communicationErrors.zimbraError(
+                                communicationErrors.ZimbraError(
                                     undefined, {
                                         code: code,
                                         detail: detail,


### PR DESCRIPTION
This small caps zimbraError, was returning errors while having one by returning a non-existing function error, the fix just capitalize is by nd make it look like : ZimbraError this should fix the problem.
